### PR TITLE
deprecated function removed

### DIFF
--- a/modules/Screeenly/Services/CaptureService.php
+++ b/modules/Screeenly/Services/CaptureService.php
@@ -4,6 +4,7 @@ namespace Screeenly\Services;
 
 use Screeenly\Entities\Url;
 use Screeenly\Contracts\CanCaptureScreenshot;
+use Illuminate\Support\Str;
 
 class CaptureService
 {
@@ -78,7 +79,7 @@ class CaptureService
     {
         $this->isUrlOnline();
 
-        $filename = uniqid().'_'.str_random(30);
+        $filename = uniqid().'_'.Str::random(30);
         $storageUrl = storage_path("app/public/{$filename}.png");
 
         return $this->browser->capture(


### PR DESCRIPTION
Laravel recommends using the `Str` and `Arr` class methods directly instead of the respective helper functions. These helper functions are [deprecated in Laravel 5.8] and will be removed in a future version.