### PR TITLE
Feature: Store IP Address in api_log table

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,8 +25,8 @@ REDIS_HOST=127.0.0.1
 REDIS_PASSWORD=null
 REDIS_PORT=6379
 
-# Mail Configurations
-# Valid mail credentials are required for the password-reset flow
+# Mail Configurations
+# Valid mail credentials are required for the password-reset flow
 MAIL_MAILER=smtp
 MAIL_HOST=smtp.mailtrap.io
 MAIL_PORT=2525

--- a/database/migrations/2021_01_18_180815_add_ip_address_column_to_api_log_table.php
+++ b/database/migrations/2021_01_18_180815_add_ip_address_column_to_api_log_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddIpAddressColumnToApiLogTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('api_log', function (Blueprint $table) {
+            $table->string('ip_address')->nullable()->after('images');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('api_log', function (Blueprint $table) {
+            $table->dropColumn(['ip_address']);
+        });
+    }
+}

--- a/modules/Screeenly/Http/Controllers/Api/v1/ScreenshotController.php
+++ b/modules/Screeenly/Http/Controllers/Api/v1/ScreenshotController.php
@@ -41,6 +41,7 @@ class ScreenshotController extends Controller
             $apiKey->apiLogs()->create([
                 'user_id' => $apiKey->user->id,
                 'images' => $screenshot->getPath(),
+                'ip_address' => $request->ip(),
             ]);
 
             return response()->json([

--- a/modules/Screeenly/Http/Controllers/Api/v2/ScreenshotController.php
+++ b/modules/Screeenly/Http/Controllers/Api/v2/ScreenshotController.php
@@ -39,6 +39,7 @@ class ScreenshotController extends Controller
         $apiKey->apiLogs()->create([
             'user_id' => $apiKey->user->id,
             'images' => $screenshot->getPath(),
+            'ip_address' => $request->ip(),
         ]);
 
         return response()->json([

--- a/modules/Screeenly/Models/ApiLog.php
+++ b/modules/Screeenly/Models/ApiLog.php
@@ -10,7 +10,7 @@ class ApiLog extends Model
 {
     use HasFactory;
 
-    protected $fillable = ['images', 'user_id'];
+    protected $fillable = ['images', 'user_id', 'ip_address'];
 
     protected $table = 'api_log';
 

--- a/tests/modules/Screeenly/integration/api/v1/ApiV1ScreenshotTest.php
+++ b/tests/modules/Screeenly/integration/api/v1/ApiV1ScreenshotTest.php
@@ -3,6 +3,7 @@
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Illuminate\Support\Facades\Storage;
 use Screeenly\Models\ApiKey;
+use Screeenly\Models\ApiLog;
 
 class ApiV1ScreenshotTest extends BrowserKitTestCase
 {
@@ -151,6 +152,11 @@ class ApiV1ScreenshotTest extends BrowserKitTestCase
             'base64',
             'base64_raw',
         ]);
+
+        $log = ApiLog::where('user_id', $apiKey->user_id)->first();
+
+        $this->assertEquals('127.0.0.1', $log->ip_address);
+        $this->assertNotNull($log->images);
     }
 
     /** @test */


### PR DESCRIPTION
The hosted version of screeenly on screeenly.com receives quite a lot of traffic. Sometimes too much traffic.

In order to reach out to users who might send too much traffic to our servers, we will start logging the used IP address to make the API requests.